### PR TITLE
bugfix: make local build closer match rtd by using dirhtml

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,7 @@
             "request": "launch",
             "module": "sphinx_autobuild",
             "args": [
+                "-b", "dirhtml",
                 "docs",
                 "docs/_build/html"
             ],

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Assuming a unix based system:
   pip install -r requirements_dev.txt
   
   # Run sphinx-autobuild
-  sphinx-autobuild docs docs/_build/html
+  sphinx-autobuild -b dirhtml docs docs/_build/html
 
 Then go to http://localhost:8000/ in a browser.
 When you save changes to a file, it should update in the browser automatically.

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 sphinx
 sphinx-togglebutton
 sphinxcontrib-opendataservices
+sphinxcontrib-redoc
 sphinxcontrib-video
 sphinxcontrib-youtube
 sphinx-intl


### PR DESCRIPTION
If https://github.com/IATI/iati-unified-platform-docs/pull/33 works then this applies the same change to the docs base