### PR TITLE
bugfix: re-add missing autosectionlabel ext

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ language = "en"
 
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosectionlabel",
     "sphinx.ext.todo",
     "sphinxcontrib.redoc",
     "sphinxcontrib.video",


### PR DESCRIPTION
After investigation, I can see that this was removed in error in  https://github.com/IATI/iati-docs-base/pull/8 

Updating to match the new base is why we then have had to rewrite a bunch of internal links in other repos. I'm re-adding it here to restore previous behaviour. 