### PR TITLE
feat: expose tool_nav_items via project_info

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,14 @@ from sphinx.locale import get_translation
 import iati_sphinx_theme
 
 # Import project-specific settings
-from project_info import project, eyebrow_text, github_repository, languages, redoc
+from project_info import (
+    project,
+    eyebrow_text,
+    github_repository,
+    languages,
+    redoc,
+    tool_nav_items,
+)
 
 MESSAGE_CATALOG_NAME = "iati-sphinx-theme"
 _ = get_translation(MESSAGE_CATALOG_NAME)
@@ -51,6 +58,7 @@ html_theme_options = {  # See https://iati-sphinx-theme.readthedocs-hosted.com/e
     "languages": languages,
     "project_title": _(project),
     "show_download_links": True,
+    "tool_nav_items": tool_nav_items,
 }
 
 # Add any paths that contain custom static files (such as style sheets, videos,

--- a/docs/project_info.py
+++ b/docs/project_info.py
@@ -23,3 +23,7 @@ redoc = [
         "template": "_templates/redoc-custom.j2",
     }
 ]
+
+# Per-tool navigation link(s) shown in the page header. Empty for repos
+# that don't represent a single tool (e.g. the docs base, multi-tool sites).
+tool_nav_items = {}


### PR DESCRIPTION
Add the only missing conf option: per-tool header navigation links can be set per repo 