### PR TITLE
feat: derive nav from project, tool_url, and nav_label

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,12 +16,24 @@ import iati_sphinx_theme
 # Import project-specific settings
 from project_info import (
     project,
+    tool_url,
+    nav_label,
     eyebrow_text,
     github_repository,
     languages,
     redoc,
-    tool_nav_items,
 )
+
+# Derive nav and title from project_info. When tool_url is set, the
+# header shows two nav items: the tool itself, and a self-link to the
+# documentation. When unset, just the self-link.
+_nav_label = nav_label or project
+if tool_url:
+    tool_nav_items = {_nav_label: tool_url}
+    project_title = f"{_nav_label}: Documentation"
+else:
+    tool_nav_items = {}
+    project_title = project
 
 MESSAGE_CATALOG_NAME = "iati-sphinx-theme"
 _ = get_translation(MESSAGE_CATALOG_NAME)
@@ -56,7 +68,7 @@ html_theme_options = {  # See https://iati-sphinx-theme.readthedocs-hosted.com/e
     "header_title_text": _(project),
     "header_eyebrow_text": _(eyebrow_text),
     "languages": languages,
-    "project_title": _(project),
+    "project_title": _(project_title),
     "show_download_links": True,
     "tool_nav_items": tool_nav_items,
 }

--- a/docs/project_info.py
+++ b/docs/project_info.py
@@ -5,6 +5,21 @@
 # Project name (used for titles, headers, and Sphinx internals)
 project = "IATI Docs Base"
 
+# URL of the live tool this repo documents. Set this for repos that
+# document a deployed tool (Validator, Datastore, Publisher, ...).
+# Leave as None for repos where the docs themselves are the deliverable
+# (legal terms, handbooks, the docs base itself).
+#
+# When set, the page header gets a two-item nav: a link to the tool, and
+# a self-link labelled "<name>: Documentation". When unset, the header
+# shows a single self-link labelled with the project name.
+tool_url = None
+
+# Short label used in the nav. Defaults to ``project``. Override only
+# when the project name is long and the nav needs a tighter label (e.g.
+# project = "Country Development Finance Data", nav_label = "CDFD").
+nav_label = None
+
 # Eyebrow text: the smaller text that appears directly above the website title
 eyebrow_text = "IATI Tools: Documentation"
 
@@ -23,7 +38,3 @@ redoc = [
         "template": "_templates/redoc-custom.j2",
     }
 ]
-
-# Per-tool navigation link(s) shown in the page header. Empty for repos
-# that don't represent a single tool (e.g. the docs base, multi-tool sites).
-tool_nav_items = {}


### PR DESCRIPTION
Auto-derive the per-tool nav and project_title from `project` + optional `tool_url` and `nav_label` instead of hand-wiring `tool_nav_items` and `project_title` per repo. Eliminates the dedup collision that hides the external tool link.