### PR TITLE
docs: fix github_repository comment to match actual theme behaviour

### DIFF
--- a/docs/project_info.py
+++ b/docs/project_info.py
@@ -23,7 +23,7 @@ nav_label = None
 # Eyebrow text: the smaller text that appears directly above the website title
 eyebrow_text = "IATI Tools: Documentation"
 
-# GitHub repository URL (for "Edit on GitHub" links)
+# GitHub repository URL (used by the theme for the "Source code at GitHub" footer link)
 github_repository = "https://github.com/IATI/iati-docs-base"
 
 # Supported languages for the documentation


### PR DESCRIPTION
The theme renders this URL as 'Source code at GitHub' in the footer, not 'Edit on GitHub'.