### PR TITLE
bugfix: specify default python for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
 		// Configure properties specific to VS Code.
 		"vscode": {
 			"settings": {
-				"cSpell.language": "en-GB"
+				"cSpell.language": "en-GB",
+				"python.defaultInterpreterPath": "/usr/local/bin/python"
 			},
 			"extensions": [
 				"ms-azuretools.vscode-docker",


### PR DESCRIPTION
I think the MS python3.13 image has changed....something....and Sphinx Autobuild no longer gets the right python. This specifies the right python for VS Code users. 